### PR TITLE
uploadInfo broke in v4.05

### DIFF
--- a/t/uploadInfo.t
+++ b/t/uploadInfo.t
@@ -70,20 +70,38 @@ my $q;
 }
 
 {
-    my $test = "uploadInfo: basic test";
-    my $fh = $q->upload('300x300_gif');
-    is( uploadInfo($fh)->{'Content-Type'}, "image/gif", $test);
-    is( $q->uploadInfo($fh)->{'Content-Type'}, "image/gif", $test);
+    # That's cheating! We shouldn't do that!
+    my $test = "All temp files are present";
+    is( scalar(keys %{$q->{'.tmpfiles'}}), 5, $test);
+}
+
+my %uploadinfo_for = (
+    'does_not_exist_gif' => {type => 'application/octet-stream', size => undef, },
+    '100;100_gif'        => {type => 'image/gif',                size => 896, },
+    '300x300_gif'        => {type => 'image/gif',                size => 1656, },
+);
+
+
+foreach my $param_name (sort keys %uploadinfo_for) {
+    my $f_type = $uploadinfo_for{$param_name}->{type};
+    my $f_size = $uploadinfo_for{$param_name}->{size};
+    my $test = "uploadInfo: $param_name";
+
+    my $fh = $q->upload($param_name);
+    is( uploadInfo($fh)->{'Content-Type'},       $f_type,    $test);
+    is( $q->uploadInfo($fh)->{'Content-Type'},   $f_type,    $test);
+    is( $q->uploadInfo($fh)->{'Content-Length'}, $f_size, $test);
 
 	# access using param
-	my $param_value = $q->param( '300x300_gif' );
+	my $param_value = $q->param($param_name);
 	ok( ref( $param_value ),'param returns filehandle' );
-    is( $q->uploadInfo( $param_value )->{'Content-Type'}, "image/gif", $test . ' via param');
+    is( $q->uploadInfo( $param_value )->{'Content-Type'},   $f_type, $test . ' via param');
+    is( $q->uploadInfo( $param_value )->{'Content-Length'}, $f_size, $test . ' via param');
 
 	# access using Vars (is not possible)
 	my $vars = $q->Vars;
-	ok( ! ref( $vars->{'300x300_gif'} ),'Vars does not return filehandle' );
-    ok( ! $q->uploadInfo( $vars->{'300x300_gif'} ), $test . ' via Vars');
+	ok( ! ref( $vars->{$param_name} ),'Vars does not return filehandle' );
+    ok( ! $q->uploadInfo( $vars->{$param_name} ), $test . ' via Vars');
 }
 
 my $q2 = CGI->new;


### PR DESCRIPTION
The only reason that it didn't show is that the uploadInfo.t test only
covers the last file in t/upload_post_text.txt which is the only one
available in $q->{'.tmpfiles'}.

Add more tests to check against other uploaded files to display the
issue.
Sadly, I don't have a fix for it.
