### PR TITLE
t\rt-84767.t fails with MSVC built perl due to dir separator

### DIFF
--- a/t/rt-84767.t
+++ b/t/rt-84767.t
@@ -18,7 +18,7 @@ open( my $fh,"<","$Script" )
 while ( <$fh> ) {
     eval { die("error") if /error/; };
     $@ && do {
-        like( $@,qr!at t/$Script line 19!,'die with input line number' );
+        like( $@,qr!at \Q$0\E line 19!,'die with input line number' );
         last;
     }
 }


### PR DESCRIPTION
Hard coded directory separator causes comparison to fail:

```
Failed test 'die with input line number'
t\rt-84767.t ............... 1/1 #   at t\rt-84767.t line 21.
                'error at t\rt-84767.t line 19.
'
doesn't match '(?^:at t/rt-84767.t line 19)'
```

Fix by using `\Q$0\E` instead of `t/$Script`.
