### PR TITLE
Taint mode blocks vulnerability

### DIFF
--- a/examples/file_upload.cgi
+++ b/examples/file_upload.cgi
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl
+#!/usr/bin/env perl -T
 
 use strict;
 use warnings;


### PR DESCRIPTION
If filename is `ARG`, the while loop will call `open()` on every thing in `@ARG` creating a remote execution vulnerability. Enabling taint mode prevents this. See my [article](http://perltricks.com/article/netanel-rubins-perljam-circus/) for details.

Another way to fix would be to use the double diamond operator `<<$file>>`. That will not call `open()`. But it requires Perl 5.22.0 or higher, which most people won't have.