### PR TITLE
Metafixes

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -51,12 +51,19 @@ WriteMakefile(
         ? ()
         : (
             META_MERGE => {
-                requires  => { perl => '5.008001' },
-                resources => {
+                'meta-spec' => { version => 2 },
+                requires    => { perl    => '5.008001' },
+                resources   => {
                     license    => 'http://dev.perl.org/licenses/',
                     homepage   => 'https://metacpan.org/module/CGI',
-                    repository => 'https://github.com/leejo/CGI.pm',
-                    bugtracker => 'https://github.com/leejo/CGI.pm/issues',
+                    repository => {
+                        url  => 'https://github.com/leejo/CGI.pm',
+                        web  => 'https://github.com/leejo/CGI.pm',
+                        type => 'git',
+                    },
+                    bugtracker => {
+                        web => 'https://github.com/leejo/CGI.pm/issues',
+                    }
                 },
                 no_index => { directory => [qw/t/] },
             },

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -60,10 +60,6 @@ WriteMakefile(
                 },
                 no_index => { directory => [qw/t/] },
             },
-            META_ADD => {
-                build_requires     => {},
-                configure_requires => {}
-            },
         )
     ),
 );


### PR DESCRIPTION
Closes #207 

The only uncertainty is "What EUMM versions is it safe to declare meta-spec version 2 in"
```
git checkout 7a30832; git clean -dfX; perl Makefile.PL; make distdir; mv CGI-4.31 /tmp/CGI-4.31;
git checkout 4b7206d; git clean -dfX; perl Makefile.PL; make distdir; mv CGI-4.31 /tmp/CGI-4.31.new;
diff -Naur /tmp/CGI-4.31 /tmp/CGI-4.31.new
```
```diff
diff -Naur /tmp/CGI-4.31/Makefile.PL /tmp/CGI-4.31.new/Makefile.PL
--- /tmp/CGI-4.31/Makefile.PL	2016-07-19 18:45:31.950346491 +1200
+++ /tmp/CGI-4.31.new/Makefile.PL	2016-07-19 18:45:46.673160311 +1200
@@ -51,19 +51,22 @@
         ? ()
         : (
             META_MERGE => {
-                requires  => { perl => '5.008001' },
-                resources => {
+                'meta-spec' => { version => 2 },
+                requires    => { perl    => '5.008001' },
+                resources   => {
                     license    => 'http://dev.perl.org/licenses/',
                     homepage   => 'https://metacpan.org/module/CGI',
-                    repository => 'https://github.com/leejo/CGI.pm',
-                    bugtracker => 'https://github.com/leejo/CGI.pm/issues',
+                    repository => {
+                        url  => 'https://github.com/leejo/CGI.pm',
+                        web  => 'https://github.com/leejo/CGI.pm',
+                        type => 'git',
+                    },
+                    bugtracker => {
+                        web => 'https://github.com/leejo/CGI.pm/issues',
+                    }
                 },
                 no_index => { directory => [qw/t/] },
             },
-            META_ADD => {
-                build_requires     => {},
-                configure_requires => {}
-            },
         )
     ),
 );
diff -Naur /tmp/CGI-4.31/META.json /tmp/CGI-4.31.new/META.json
--- /tmp/CGI-4.31/META.json	2016-07-19 18:45:32.585338458 +1200
+++ /tmp/CGI-4.31.new/META.json	2016-07-19 18:45:47.344151830 +1200
@@ -22,10 +22,14 @@
    },
    "prereqs" : {
       "build" : {
-         "requires" : {}
+         "requires" : {
+            "ExtUtils::MakeMaker" : "0"
+         }
       },
       "configure" : {
-         "requires" : {}
+         "requires" : {
+            "ExtUtils::MakeMaker" : "0"
+         }
       },
       "runtime" : {
          "requires" : {
@@ -45,6 +49,18 @@
             "utf8" : "0",
             "warnings" : "0"
          }
+      },
+      "test" : {
+         "requires" : {
+            "Cwd" : "0",
+            "File::Find" : "0",
+            "IO::File" : "0",
+            "IO::Handle" : "0",
+            "POSIX" : "0",
+            "Test::Deep" : "0.11",
+            "Test::More" : "0.98",
+            "Test::Warn" : "0.3"
+         }
       }
    },
    "release_status" : "stable",
@@ -57,7 +73,9 @@
          "http://dev.perl.org/licenses/"
       ],
       "repository" : {
-         "url" : "https://github.com/leejo/CGI.pm"
+         "type" : "git",
+         "url" : "https://github.com/leejo/CGI.pm",
+         "web" : "https://github.com/leejo/CGI.pm"
       }
    },
    "version" : "4.31",
diff -Naur /tmp/CGI-4.31/META.yml /tmp/CGI-4.31.new/META.yml
--- /tmp/CGI-4.31/META.yml	2016-07-19 18:45:32.428340444 +1200
+++ /tmp/CGI-4.31.new/META.yml	2016-07-19 18:45:47.162154130 +1200
@@ -2,8 +2,18 @@
 abstract: 'Handle Common Gateway Interface requests and responses'
 author:
   - unknown
-build_requires: {}
-configure_requires: {}
+build_requires:
+  Cwd: '0'
+  ExtUtils::MakeMaker: '0'
+  File::Find: '0'
+  IO::File: '0'
+  IO::Handle: '0'
+  POSIX: '0'
+  Test::Deep: '0.11'
+  Test::More: '0.98'
+  Test::Warn: '0.3'
+configure_requires:
+  ExtUtils::MakeMaker: '0'
 dynamic_config: 1
 generated_by: 'ExtUtils::MakeMaker version 7.1001, CPAN::Meta::Converter version 2.150005'
 license: perl
```