### PR TITLE
Replace only use of "base" with "parent"

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -14,7 +14,6 @@ my %WriteMakefileArgs = (
     PREREQ_PM        => {
         'Carp'           => 0,     # Carp was first released with perl 5
         'Exporter'       => 0,     # Exporter was first released with perl 5
-        'base'           => 0,     # base was first released with perl 5.00405
         'overload'       => 0,     # overload was first released with perl 5.002
         'strict'         => 0,     # strict was first released with perl 5
         'utf8'           => 0,     # utf8 was first released with perl v5.6.0

--- a/lib/CGI/Util.pm
+++ b/lib/CGI/Util.pm
@@ -1,5 +1,5 @@
 package CGI::Util;
-use base 'Exporter';
+use parent 'Exporter';
 require 5.008001;
 use strict;
 use if $] >= 5.019, 'deprecate';


### PR DESCRIPTION
CGI.pm already depends on parent, may as well use it place of base
everywhere.