### PR TITLE
adding support for Samesite=None attribute

### DIFF
--- a/lib/CGI/Cookie.pm
+++ b/lib/CGI/Cookie.pm
@@ -230,7 +230,7 @@ sub httponly { # HttpOnly
     return $self->{'httponly'};
 }
 
-my %_legal_samesite = ( Strict => 1, Lax => 1 );
+my %_legal_samesite = ( Strict => 1, Lax => 1, None => 1 );
 sub samesite { # SameSite
     my $self = shift;
     my $samesite = ucfirst lc +shift if @_; # Normalize casing.


### PR DESCRIPTION
**Description:** As per the google chrome updates here (https://www.chromestatus.com/feature/5633521622188032), we need to explicitly set `SameSite=None` cookie. But `CGI::Cookie.pm` currently lacks this support. 
This PR adds the support for `SameSite=None` cookie and is successfully tested at my end.