### PR TITLE
feat: Add APPEND_QUERY_STRING option

### DIFF
--- a/lib/CGI.pm
+++ b/lib/CGI.pm
@@ -90,6 +90,9 @@ sub initialize_globals {
     # make param('PUTDATA') act like file upload
     $PUTDATA_UPLOAD = 0;
 
+    # Add QUERY_STRING to POST request
+    $APPEND_QUERY_STRING = 0;
+
     # Other globals that you shouldn't worry about.
     undef $Q;
     $BEEN_THERE = 0;
@@ -553,6 +556,12 @@ sub init {
 	  ) {
 	  my($boundary) = $ENV{'CONTENT_TYPE'} =~ /boundary=\"?([^\";,]+)\"?/;
 	  $self->read_multipart($boundary,$content_length);
+	  if ($APPEND_QUERY_STRING) {
+	    # Some people want to have their cake and eat it too!
+	    # Set $APPEND_QUERY_STRING = 1 to have the contents of the query string
+	    # APPENDED to the POST data.
+	    $query_string .= (length($query_string) ? '&' : '') . $ENV{'QUERY_STRING'} if defined $ENV{'QUERY_STRING'};
+	  }
 	  last METHOD;
       } 
 
@@ -651,10 +660,12 @@ sub init {
             $self->read_from_client(\$query_string,$content_length,0);
         }
 	  }
-	  # Some people want to have their cake and eat it too!
-	  # Uncomment this line to have the contents of the query string
-	  # APPENDED to the POST data.
-	  # $query_string .= (length($query_string) ? '&' : '') . $ENV{'QUERY_STRING'} if defined $ENV{'QUERY_STRING'};
+	  if ($APPEND_QUERY_STRING) {
+	    # Some people want to have their cake and eat it too!
+	    # Set $APPEND_QUERY_STRING = 1 to have the contents of the query string
+	    # APPENDED to the POST data.
+	    $query_string .= (length($query_string) ? '&' : '') . $ENV{'QUERY_STRING'} if defined $ENV{'QUERY_STRING'};
+	  }
 	  last METHOD;
       }
 

--- a/lib/CGI.pod
+++ b/lib/CGI.pod
@@ -1718,6 +1718,22 @@ However it isn't clear that any browser currently knows what to do with this
 status code. It might be better just to create a page that warns the user of
 the problem.
 
+=head1 MODULE FLAGS
+
+There are a number of global module flags which affect how CGI.pm operates.
+
+=over 4
+
+=item B<$CGI::APPEND_QUERY_STRING>
+
+If set to a non-zero value, this will add query string parameters to a POST
+forms parameters hence allowing I<param()> to return values from the query
+string as well as from the decoded POST request instead of having to use
+I<url_param> instead. This makes it easier to get the value of a parameter
+when you don't know the source.
+
+=back
+
 =head1 COMPATIBILITY WITH CGI-LIB.PL
 
 To make it easier to port existing programs that use cgi-lib.pl the

--- a/t/append_query.t
+++ b/t/append_query.t
@@ -1,0 +1,81 @@
+#!/usr/local/bin/perl
+
+use strict;
+use warnings;
+
+use Test::More tests => 18;
+use Test::Deep;
+
+use CGI ();
+use Config;
+
+my $loaded = 1;
+
+$| = 1;
+
+######################### End of black magic.
+
+my $test_string = 'game=soccer&game=baseball&weather=nice';
+
+# Set up a CGI environment
+$ENV{REQUEST_METHOD}  = 'POST';
+$ENV{QUERY_STRING}    = 'big_balls=basketball&small_balls=golf';
+$ENV{PATH_INFO}       = '/somewhere/else';
+$ENV{PATH_TRANSLATED} = '/usr/local/somewhere/else';
+$ENV{SCRIPT_NAME}     = '/cgi-bin/foo.cgi';
+$ENV{SERVER_PROTOCOL} = 'HTTP/1.0';
+$ENV{SERVER_PORT}     = 8080;
+$ENV{SERVER_NAME}     = 'the.good.ship.lollypop.com';
+$ENV{REQUEST_URI}     = "$ENV{SCRIPT_NAME}$ENV{PATH_INFO}?$ENV{QUERY_STRING}";
+$ENV{HTTP_LOVE}       = 'true';
+$ENV{CONTENT_LENGTH}  = length($test_string);
+
+# APPEND_QUERY_STRING unset
+{
+    local *STDIN;
+    open STDIN, '<', \$test_string;
+
+    my $q = CGI->new;
+    ok $q,"CGI::new()";
+    is $q->param('weather'), 'nice',"CGI::param() from POST";
+    is $q->param('big_balls'), undef, "CGI::param() from QUERY_STRING";
+    is $q->param('small_balls'), undef,"CGI::param() from QUERY_STRING";
+    is $q->url_param('big_balls'), 'basketball',"CGI::url_param()";
+    is $q->url_param('small_balls'), 'golf',"CGI::url_param()";
+}
+
+# APPEND_QUERY_STRING = 0
+{
+    CGI::_reset_globals;
+
+    $CGI::APPEND_QUERY_STRING = 0;
+
+    local *STDIN;
+    open STDIN, '<', \$test_string;
+
+    my $q = CGI->new;
+    ok $q,"CGI::new()";
+    is $q->param('weather'), 'nice',"CGI::param() from POST";
+    is $q->param('big_balls'), undef, "CGI::param() from QUERY_STRING";
+    is $q->param('small_balls'), undef,"CGI::param() from QUERY_STRING";
+    is $q->url_param('big_balls'), 'basketball',"CGI::url_param()";
+    is $q->url_param('small_balls'), 'golf',"CGI::url_param()";
+}
+
+# APPEND_QUERY_STRING = 1
+{
+    CGI::_reset_globals;
+
+    $CGI::APPEND_QUERY_STRING = 1;
+
+    local *STDIN;
+    open STDIN, '<', \$test_string;
+
+    my $q = CGI->new;
+    ok $q,"CGI::new()";
+    is $q->param('weather'), 'nice',"CGI::param() from POST";
+    is $q->param('big_balls'), 'basketball',"CGI::param() from QUERY_STRING";
+    is $q->param('small_balls'), 'golf',"CGI::param() from QUERY_STRING";
+    is $q->url_param('big_balls'), 'basketball',"CGI::url_param()";
+    is $q->url_param('small_balls'), 'golf',"CGI::url_param()";
+}


### PR DESCRIPTION
Expose the ability to append query string to post fields by setting:
```perl
$CGI::APPEND_QUERY_STRING = 1;
```

Instead of having to edit `CGI.pm`.