### PR TITLE
add documentation for `None` samesite cookie

### DIFF
--- a/lib/CGI/Cookie.pm
+++ b/lib/CGI/Cookie.pm
@@ -337,7 +337,7 @@ See these URLs for more information:
 
 =item B<6. samesite flag>
 
-Allowed settings are C<Strict> and C<Lax>.
+Allowed settings are C<Strict>, C<Lax> and C<None>.
 
 As of June 2016, support is limited to recent releases of Chrome and Opera.
 


### PR DESCRIPTION
It seems this has been overlooked in 89ebcdb5355bb57ebe83b8febd33c7f2c8fb7298 when resolving #238 

I had to open the code to find out that `None` is already supported.