### PR TITLE
fix parsed cookies cache inside $cgi->cookie(...)

### DIFF
--- a/lib/CGI.pm
+++ b/lib/CGI.pm
@@ -2773,7 +2773,7 @@ sub cookie {
     # value of the cookie, if any.  For efficiency, we cache the parsed
     # cookies in our state variables.
     unless ( defined($value) ) {
-	$self->{'.cookies'} = CGI::Cookie->fetch;
+	$self->{'.cookies'} = CGI::Cookie->fetch unless exists $self->{'.cookies'};
 	
 	# If no name is supplied, then retrieve the names of all our cookies.
 	return () unless $self->{'.cookies'};

--- a/lib/CGI.pm
+++ b/lib/CGI.pm
@@ -28,6 +28,7 @@ $UNLINK_TMP_FILES    = 1;
 $LIST_CONTEXT_WARN   = 1;
 $ENCODE_ENTITIES     = q{&<>"'};
 $ALLOW_DELETE_CONTENT = 0;
+$COOKIE_CACHE        = 0;  # backcompat: cache was broken for years
 
 @SAVED_SYMBOLS = ();
 
@@ -2773,7 +2774,7 @@ sub cookie {
     # value of the cookie, if any.  For efficiency, we cache the parsed
     # cookies in our state variables.
     unless ( defined($value) ) {
-	$self->{'.cookies'} = CGI::Cookie->fetch unless exists $self->{'.cookies'};
+	$self->{'.cookies'} = CGI::Cookie->fetch unless $COOKIE_CACHE && exists $self->{'.cookies'};
 	
 	# If no name is supplied, then retrieve the names of all our cookies.
 	return () unless $self->{'.cookies'};

--- a/t/issue-251.t
+++ b/t/issue-251.t
@@ -6,7 +6,7 @@ use strict;
 use warnings;
 no warnings 'redefine';
 
-use Test::More tests => 4;
+use Test::More tests => 2;
 
 use CGI::Cookie ();
 use CGI ();
@@ -20,11 +20,26 @@ local *CGI::Cookie::fetch = sub {
     goto &$fetch_orig_sub;
 };
 
-my $q = CGI->new;
+subtest 'cookie cache disabled' => sub {
+    plan tests => 4;
+    $fetch_counter = 0;
+    $CGI::COOKIE_CACHE = 0;
 
-is($q->cookie('cookie1'), 'value1', 'cookie1 is correct');
-is($q->cookie('cookie2'), 'value2', 'cookie2 is correct');
-is($q->cookie('cookie3'), 'value3', 'cookie3 is correct');
+    my $q = CGI->new;
+    is($q->cookie('cookie1'), 'value1', 'cookie1 is correct');
+    is($q->cookie('cookie2'), 'value2', 'cookie2 is correct');
+    is($q->cookie('cookie3'), 'value3', 'cookie3 is correct');
+    is($fetch_counter, 3, 'cookies were fetched on each `cookie` call');
+};
 
-is($fetch_counter, 1, 'cookies were fetched only once');
+subtest 'cookie cache enabled' => sub {
+    plan tests => 4;
+    $fetch_counter = 0;
+    $CGI::COOKIE_CACHE = 1;
 
+    my $q = CGI->new;
+    is($q->cookie('cookie1'), 'value1', 'cookie1 is correct');
+    is($q->cookie('cookie2'), 'value2', 'cookie2 is correct');
+    is($q->cookie('cookie3'), 'value3', 'cookie3 is correct');
+    is($fetch_counter, 1, 'cookies were fetched only once');
+};

--- a/t/issue-251.t
+++ b/t/issue-251.t
@@ -1,0 +1,30 @@
+#!/usr/local/bin/perl
+
+# test for https://github.com/leejo/CGI.pm/issues/251
+
+use strict;
+use warnings;
+no warnings 'redefine';
+
+use Test::More tests => 4;
+
+use CGI::Cookie ();
+use CGI ();
+
+local $ENV{HTTP_COOKIE} = 'cookie1=value1; cookie2=value2; cookie3=value3';
+
+my $fetch_counter = 0;
+my $fetch_orig_sub = \&CGI::Cookie::fetch;
+local *CGI::Cookie::fetch = sub {
+    $fetch_counter++;
+    goto &$fetch_orig_sub;
+};
+
+my $q = CGI->new;
+
+is($q->cookie('cookie1'), 'value1', 'cookie1 is correct');
+is($q->cookie('cookie2'), 'value2', 'cookie2 is correct');
+is($q->cookie('cookie3'), 'value3', 'cookie3 is correct');
+
+is($fetch_counter, 1, 'cookies were fetched only once');
+


### PR DESCRIPTION
Benchmark:
```
$ HTTP_COOKIE="cookie1=value1; cookie2=value2; cookie3=value3" \
> perl -MCGI -MBenchmark -e'my $cgi = CGI->new; timethis(-1, sub { $cgi->cookie("cookie2") })'
```

Benchmark results:
```
timethis for 1:  1 wallclock secs ( 1.06 usr +  0.00 sys =  1.06 CPU) @ 77283.02/s (n=81920) # new
timethis for 1:  1 wallclock secs ( 1.13 usr +  0.01 sys =  1.14 CPU) @ 8274.56/s (n=9433)   # old
```
Fixes #251 