### PR TITLE
drop prereq on Test::Deep

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -32,7 +32,6 @@ my %WriteMakefileArgs = (
         'IO::File'         => 0,    # IO::File was first released with perl 5.00307
         'IO::Handle'       => 0,    # IO::Handle was first released with perl 5.00307
         'File::Find'       => 0,    # File::Find was first released with perl 5
-        'Test::Deep'       => 0.11,
         'Test::More'       => 0.98,
         'Test::Warn'       => 0.30,
         'Test::NoWarnings' => 0,

--- a/t/append_query.t
+++ b/t/append_query.t
@@ -4,7 +4,6 @@ use strict;
 use warnings;
 
 use Test::More tests => 18;
-use Test::Deep;
 
 use CGI ();
 use Config;

--- a/t/cgi.t
+++ b/t/cgi.t
@@ -6,7 +6,6 @@ use strict;
 use warnings;
 
 use Test::More tests => 25;
-use Test::Deep;
 
 use CGI ();
 
@@ -27,7 +26,7 @@ is( $q->PrintHeader,$q->header,'PrintHeader' );
 is( $q->HtmlTop,$q->start_html,'HtmlTop' );
 is( $q->HtmlBot,$q->end_html,'HtmlBot' );
 
-cmp_deeply(
+is_deeply(
 	[ my @params = CGI::SplitParam( "foo\0bar" ) ],
 	[ qw/ foo bar /],
 	'SplitParam'
@@ -60,7 +59,7 @@ $CGI::CLOSE_UPLOAD_FILES = 0;
 ok( $q->close_upload_files( 1 ),'close_upload_files' );
 is( $CGI::CLOSE_UPLOAD_FILES,1,' ... sets $CGI::CLOSE_UPLOAD_FILES' );
 
-cmp_deeply(
+is_deeply(
 	$q->default_dtd,
 	[
 		'-//W3C//DTD HTML 4.01 Transitional//EN',

--- a/t/command_line.t
+++ b/t/command_line.t
@@ -7,7 +7,6 @@ use warnings;
 use File::Temp qw(tempfile);
 
 use Test::More;
-use Test::Deep;
 
 if ( $^O =~ /^MSWin/i ) {
   plan skip_all => "No relevant to Windows";

--- a/t/param_list_context.t
+++ b/t/param_list_context.t
@@ -4,7 +4,6 @@ use strict;
 use warnings;
 
 use Test::More;
-use Test::Deep;
 use Test::Warn;
 
 use CGI ();
@@ -33,7 +32,7 @@ warnings_are
 
 warning_like
 	{ @params = $q->param('game') }
-	qr/CGI::param called in list context from .+param_list_context\.t line 35, this can lead to vulnerabilities/,
+	qr/CGI::param called in list context from .+param_list_context\.t line 34, this can lead to vulnerabilities/,
     "calling ->param with args in list context warns"
 ;
 
@@ -43,7 +42,7 @@ warnings_are
     " ... but we only warn once",
 ;
 
-cmp_deeply(
+is_deeply(
 	[ sort @params ],
 	[ qw/ checkers chess / ],
 	'CGI::param()',
@@ -55,7 +54,7 @@ warnings_are
 	"no warnings calling multi_param"
 ;
 
-cmp_deeply(
+is_deeply(
 	[ sort @params ],
 	[ qw/ checkers chess / ],
 	'CGI::multi_param'

--- a/t/request.t
+++ b/t/request.t
@@ -4,7 +4,6 @@ use strict;
 use warnings;
 
 use Test::More tests => 71;
-use Test::Deep;
 
 use CGI ();
 use Config;
@@ -124,7 +123,7 @@ $q->_reset_globals;
 		$q = CGI->new;
 		$ENV{QUERY_STRING} = 'p1=1&&&;;&;&&;;p2;p3;p4=4&=p5';
 		ok $q->url_param, 'url_param() is true if parameters';
-		cmp_deeply( [ $q->url_param ],bag( qw/p1 p2 p3 p4/,'' ),'url_param' );
+		is_deeply( [ sort $q->url_param ], [ '', qw/p1 p2 p3 p4/ ], 'url_param' );
 	}
 }
 

--- a/t/util.t
+++ b/t/util.t
@@ -6,7 +6,6 @@
 $| = 1;
 
 use Test::More tests => 80;
-use Test::Deep;
 use Config;
 use_ok ( 'CGI::Util', qw(
 	escape
@@ -68,7 +67,7 @@ for ( 1 .. 20 ) {
 		%args,
 	);
 
-	cmp_deeply(
+	is_deeply(
 		[ @ordered ],
 		[
 			'text/html; charset=iso-8859-1',


### PR DESCRIPTION
Test::Deep was barely used by this dist, and is trivially replaced with Test::More::is_deeply. Test::Deep will soon be requiring perl 5.10, which would needlessly limit the installation of this module.