### PR TITLE
Update cookie expires date format

### DIFF
--- a/lib/CGI.pm
+++ b/lib/CGI.pm
@@ -1607,9 +1607,9 @@ sub header {
     # if the user indicates an expiration time, then we need
     # both an Expires and a Date header (so that the browser is
     # uses OUR clock)
-    push(@header,"Expires: " . expires($expires,'http'))
+    push(@header,"Expires: " . expires($expires))
 	if $expires;
-    push(@header,"Date: " . expires(0,'http')) if $expires || $cookie || $nph;
+    push(@header,"Date: " . expires(0)) if $expires || $cookie || $nph;
     push(@header,"Pragma: no-cache") if $self->cache();
     push(@header,"Content-Disposition: attachment; filename=\"$attachment\"") if $attachment;
     push(@header,map {ucfirst $_} @other);
@@ -2761,7 +2761,7 @@ sub url {
 #   -path -> paths for which this cookie is valid (optional)
 #   -domain -> internet domain in which this cookie is valid (optional)
 #   -secure -> if true, cookie only passed through secure channel (optional)
-#   -expires -> expiry date in format Wdy, DD-Mon-YYYY HH:MM:SS GMT (optional)
+#   -expires -> expiry date in format Wdy, DD Mon YYYY HH:MM:SS GMT (optional)
 ####
 sub cookie {
     my($self,@p) = self_or_default(@_);

--- a/lib/CGI/Cookie.pm
+++ b/lib/CGI/Cookie.pm
@@ -209,7 +209,7 @@ sub secure {
 
 sub expires {
     my ( $self, $expires ) = @_;
-    $self->{'expires'} = CGI::Util::expires($expires,'cookie') if defined $expires;
+    $self->{'expires'} = CGI::Util::expires($expires) if defined $expires;
     return $self->{'expires'};
 }
 

--- a/lib/CGI/Util.pm
+++ b/lib/CGI/Util.pm
@@ -244,8 +244,7 @@ sub escape {
 # cookies and HTTP headers.  (They differ, unfortunately.)
 # Thanks to Mark Fisher for this.
 sub expires {
-    my($time,$format) = @_;
-    $format ||= 'http';
+    my $time = shift;
 
     my(@MON)=qw/Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec/;
     my(@WDAY) = qw/Sun Mon Tue Wed Thu Fri Sat/;
@@ -254,13 +253,9 @@ sub expires {
     $time = expire_calc($time);
     return $time unless $time =~ /^\d+$/;
 
-    # make HTTP/cookie date string from GMT'ed time
-    # (cookies use '-' as date separator, HTTP uses ' ')
-    my($sc) = ' ';
-    $sc = '-' if $format eq "cookie";
     my($sec,$min,$hour,$mday,$mon,$year,$wday) = gmtime($time);
     $year += 1900;
-    return sprintf("%s, %02d$sc%s$sc%04d %02d:%02d:%02d GMT",
+    return sprintf("%s, %02d %s %04d %02d:%02d:%02d GMT",
                    $WDAY[$wday],$mday,$MON[$mon],$year,$hour,$min,$sec);
 }
 

--- a/t/cookie.t
+++ b/t/cookie.t
@@ -163,7 +163,7 @@ my @test_cookie = (
   is(ref($c), 'CGI::Cookie', 'new returns objects of correct type');
   is($c->name   , 'foo',               'name is correct');
   is($c->value  , 'bar',               'value is correct');
-  like($c->expires, '/^[a-z]{3},\s*\d{2}-[a-z]{3}-\d{4}/i', 'expires in correct format');
+  like($c->expires, '/^[a-z]{3},\s*\d{2}\s[a-z]{3}\s\d{4}/i', 'expires in correct format');
   is($c->domain , '.capricorn.com',    'domain is correct');
   is($c->path   , '/cgi-bin/database', 'path is correct');
   ok($c->secure , 'secure attribute is set');
@@ -357,9 +357,9 @@ my @test_cookie = (
   is($c->value,           'Gerbil',  'value now returns updated value');
 
   my $exp = $c->expires;
-  like($c->expires,         '/^[a-z]{3},\s*\d{2}-[a-z]{3}-\d{4}/i', 'expires is correct');
-  like($c->expires('+12h'), '/^[a-z]{3},\s*\d{2}-[a-z]{3}-\d{4}/i', 'expires is set correctly');
-  like($c->expires,         '/^[a-z]{3},\s*\d{2}-[a-z]{3}-\d{4}/i', 'expires now returns updated value');
+  like($c->expires,         '/^[a-z]{3},\s*\d{2}\s[a-z]{3}\s\d{4}/i', 'expires is correct');
+  like($c->expires('+12h'), '/^[a-z]{3},\s*\d{2}\s[a-z]{3}\s\d{4}/i', 'expires is set correctly');
+  like($c->expires,         '/^[a-z]{3},\s*\d{2}\s[a-z]{3}\s\d{4}/i', 'expires now returns updated value');
   isnt($c->expires, $exp, "Expiry time has changed");
 
   is($c->domain,                  '.pie-shop.com', 'domain is correct');
@@ -398,7 +398,7 @@ my @test_cookie = (
 
 MAX_AGE: {
     my $cookie = CGI::Cookie->new( -name=>'a', value=>'b', '-expires' => 'now',);
-    is $cookie->expires, 'Thu, 01-Jan-1970 00:01:40 GMT', 'expires is correct';
+    is $cookie->expires, 'Thu, 01 Jan 1970 00:01:40 GMT', 'expires is correct';
     is $cookie->max_age => undef, 'max-age is undefined when setting expires';
 
     $cookie = CGI::Cookie->new( -name=>'a', 'value'=>'b' );


### PR DESCRIPTION
Hey Lee

The preferred format for expiry values is the same in cookies as it is in HTTP headers. Change is described here:

https://www.rfc-editor.org/rfc/rfc2616#section-3.3.1

Basically, replace hyphens with spaces. 

Hope all is well in sunny, erm, Switzeland?

Cheers


Robbie