### PR TITLE
support `Partitioned`

### DIFF
--- a/lib/CGI/Cookie.pm
+++ b/lib/CGI/Cookie.pm
@@ -104,14 +104,14 @@ sub new {
   # Ignore mod_perl request object--compatibility with Apache::Cookie.
   shift if ref $params[0]
         && eval { $params[0]->isa('Apache::Request::Req') || $params[0]->isa('Apache') };
-  my ( $name, $value, $path, $domain, $secure, $expires, $max_age, $httponly, $samesite, $priority )
+  my ( $name, $value, $path, $domain, $secure, $expires, $max_age, $httponly, $samesite, $priority, $partitioned )
    = rearrange(
     [
       'NAME', [ 'VALUE', 'VALUES' ],
       'PATH',   'DOMAIN',
       'SECURE', 'EXPIRES',
       'MAX-AGE','HTTPONLY','SAMESITE',
-      'PRIORITY',
+      'PRIORITY', 'PARTITIONED',
     ],
     @params
    );
@@ -121,14 +121,15 @@ sub new {
   $self->name( $name );
   $self->value( $value );
   $path ||= "/";
-  $self->path( $path )         if defined $path;
-  $self->domain( $domain )     if defined $domain;
-  $self->secure( $secure )     if defined $secure;
-  $self->expires( $expires )   if defined $expires;
-  $self->max_age( $max_age )   if defined $max_age;
-  $self->httponly( $httponly ) if defined $httponly;
-  $self->samesite( $samesite ) if defined $samesite;
-  $self->priority( $priority ) if defined $priority;
+  $self->path( $path )               if defined $path;
+  $self->domain( $domain )           if defined $domain;
+  $self->secure( $secure )           if defined $secure;
+  $self->expires( $expires )         if defined $expires;
+  $self->max_age( $max_age )         if defined $max_age;
+  $self->httponly( $httponly )       if defined $httponly;
+  $self->samesite( $samesite )       if defined $samesite;
+  $self->priority( $priority )       if defined $priority;
+  $self->partitioned( $partitioned ) if defined $partitioned;
   return $self;
 }
 
@@ -150,6 +151,7 @@ sub as_string {
     push @cookie,"HttpOnly"                  if $self->httponly;
     push @cookie,"SameSite=".$self->samesite if $self->samesite;
     push @cookie,"Priority=".$self->priority if $self->priority;
+    push @cookie,"Partitioned"               if $self->partitioned;
 
     return join "; ", @cookie;
 }
@@ -229,6 +231,12 @@ sub httponly { # HttpOnly
     my ( $self, $httponly ) = @_;
     $self->{'httponly'} = $httponly if defined $httponly;
     return $self->{'httponly'};
+}
+
+sub partitioned { # Partitioned
+    my ( $self, $partitioned ) = @_;
+    $self->{'partitioned'} = $partitioned if defined $partitioned;
+    return $self->{'partitioned'};
 }
 
 my %_legal_samesite = ( Strict => 1, Lax => 1, None => 1 );

--- a/t/cookie.t
+++ b/t/cookie.t
@@ -159,6 +159,7 @@ my @test_cookie = (
                -httponly=> 1,
                -samesite=> 'Lax',
                -priority=> 'High',
+               -partitioned=> 1,
               );
   is(ref($c), 'CGI::Cookie', 'new returns objects of correct type');
   is($c->name   , 'foo',               'name is correct');
@@ -170,6 +171,7 @@ my @test_cookie = (
   ok( $c->httponly, 'httponly attribute is set' );
   is( $c->samesite, 'Lax', 'samesite attribute is correct' );
   is( $c->priority, 'High', 'priority attribute is correct' );
+  is( $c->partitioned, 1, 'partitioned attribute is correct' );
 
   # now try it with the only two manditory values (should also set the default path)
   $c = CGI::Cookie->new(-name    =>  'baz',
@@ -185,6 +187,7 @@ my @test_cookie = (
   ok(!defined $c->secure ,       'secure attribute is set');
   ok( !defined $c->httponly, 'httponly attribute is not set' );
   ok( !$c->samesite, 'samesite attribute is not set' );
+  ok( !$c->partitioned, 'partitioned attribute is not set' );
 
 # I'm really not happy about the restults of this section.  You pass
 # the new method invalid arguments and it just merilly creates a
@@ -220,6 +223,7 @@ my @test_cookie = (
                -httponly=> 1,
                -samesite=> 'strict',
                -priority=> 'high',
+               -partitioned=> 1,
               );
 
   my $name = $c->name;
@@ -251,6 +255,9 @@ my @test_cookie = (
   like( $c->as_string, '/Priority=High/',
     "Stringified cookie contains normalized Priority" );
 
+  like( $c->as_string, '/Partitioned/',
+    "Stringified cookie contains Partitioned" );
+
   $c = CGI::Cookie->new(-name    =>  'Hamster-Jam',
             -value   =>  'Tulip',
                );
@@ -280,6 +287,9 @@ my @test_cookie = (
 
   ok( $c->as_string !~ /Priority/,
     "Stringified cookie does not contain Priority" );
+
+  ok( $c->as_string !~ /Partitioned/,
+    "Stringified cookie does not contain Partitioned" );
 }
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
still experimental, but already implemented in most browsers, see https://developer.mozilla.org/en-US/docs/Web/Privacy/Partitioned_cookies https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#partitioned https://datatracker.ietf.org/doc/html/draft-cutler-httpbis-partitioned-cookies#section-2.1