### PR TITLE
Remove badges from CGI.pod and README.md and other minor tweaks to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,6 @@
 
 CGI - Handle Common Gateway Interface requests and responses
 
-<div>
-
-    <a href='https://travis-ci.org/leejo/CGI.pm?branch=master'><img src='https://travis-ci.org/leejo/CGI.pm.svg?branch=master' alt='Build Status' /></a>
-    <a href='https://coveralls.io/r/leejo/CGI.pm'><img src='https://coveralls.io/repos/leejo/CGI.pm/badge.png?branch=master' alt='Coverage Status' /></a>
-</div>
-
 # SYNOPSIS
 
     use strict;
@@ -15,7 +9,7 @@ CGI - Handle Common Gateway Interface requests and responses
 
     use CGI;
 
-        # create a CGI object (query) for use
+    # create a CGI object (query) for use
     my $q = CGI->new;
 
     # Process an HTTP request
@@ -92,7 +86,7 @@ module. If you plan to upgrade to v4.00 and beyond you should read the Changes
 file for more information and **test your code** against CGI.pm before deploying
 it.
 
-# HTML Generation functions should no longer be used
+# HTML generation functions should no longer be used
 
 **All** HTML generation functions within CGI.pm are no longer being
 maintained. Any issues, bugs, or patches will be rejected unless

--- a/lib/CGI.pod
+++ b/lib/CGI.pod
@@ -3,10 +3,6 @@
 
 CGI - Handle Common Gateway Interface requests and responses
 
-=for html
-<a href='https://travis-ci.org/leejo/CGI.pm?branch=master'><img src='https://travis-ci.org/leejo/CGI.pm.svg?branch=master' alt='Build Status' /></a>
-<a href='https://coveralls.io/r/leejo/CGI.pm'><img src='https://coveralls.io/repos/leejo/CGI.pm/badge.png?branch=master' alt='Coverage Status' /></a>
-
 =head1 SYNOPSIS
 
     use strict;
@@ -14,7 +10,7 @@ CGI - Handle Common Gateway Interface requests and responses
 
     use CGI;
 
-	# create a CGI object (query) for use
+    # create a CGI object (query) for use
     my $q = CGI->new;
 
     # Process an HTTP request
@@ -91,7 +87,7 @@ module. If you plan to upgrade to v4.00 and beyond you should read the Changes
 file for more information and B<test your code> against CGI.pm before deploying
 it.
 
-=head1 HTML Generation functions should no longer be used
+=head1 HTML generation functions should no longer be used
 
 B<All> HTML generation functions within CGI.pm are no longer being
 maintained. Any issues, bugs, or patches will be rejected unless


### PR DESCRIPTION
As discussed in issue #274, this PR removes the badges from CGI.pod and README.md. It also fixes a tab indentation that should have been spaces, and it lowercases a word in a section title that shouldn't have been capitalized.